### PR TITLE
Breakage when settings.php doesn't initially exist.

### DIFF
--- a/drupal_test_case.php
+++ b/drupal_test_case.php
@@ -2412,8 +2412,13 @@ class DrupalWebTestCase extends DrupalTestCase {
 
     $db = parse_url(UPAL_DB_URL);
 
+    // Attempt to make settings.php writable.
+    if (file_exists("$site/settings.php") && !is_writable("$site/settings.php")) {
+      chmod("$site/settings.php", 0666);
+    }
+
     // Overwrite settings.php every time, since DB credentials can change.
-    if (is_writable("$site/settings.php")) {
+    if (!file_exists("$site/settings.php") || is_writable("$site/settings.php")) {
       $byline = '// Written by the Upal Test Framework. See DrupalWebTestCase::setUp().';
       $db_array = array(
         'driver' => $db['scheme'],


### PR DESCRIPTION
When settings.php doesn't initially exist, the `$database` array wasn't properly written to the file, since `is_writable("$site/settings.php")` returns false. This resulted in subsequent test runs failing.
